### PR TITLE
factors in dataframes caused error in build.nodes.

### DIFF
--- a/R/build.nodes.1.R
+++ b/R/build.nodes.1.R
@@ -33,7 +33,7 @@ function(tree, tips)
   xF1 <- xF[xF$sizeF == 1, ]
   if (dim(xF1)[1] > 0)
     {
-      Fn1 <- data.frame(level = "F", family = xF1$family, genus = "", rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = xF1$species)
+      Fn1 <- data.frame(level = "F", family = xF1$family, genus = "", rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = xF1$species, stringsAsFactors = FALSE)
       for (i in 1 : dim(Fn1)[1])
         {
           x0 <- match(Fn1$taxa[i], tree$tip.label)
@@ -60,7 +60,7 @@ function(tree, tips)
       n2 <- length(tF$tip.label) + 1 - which(!duplicated(rev(tF$tip.label)))
       nn <- sort(unique(c(n1, n2)))
       tF <- drop.tip(tF, setdiff(1 : length(tF$tip.label), nn))
-      Fn2 <- data.frame(level = "F", family = xF2$family, genus = "", rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = "")
+      Fn2 <- data.frame(level = "F", family = xF2$family, genus = "", rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = "", stringsAsFactors = FALSE)
       x <- 1 : length(tF$tip.label)
       for (i in 1 : dim(Fn2)[1])
         {
@@ -102,7 +102,7 @@ function(tree, tips)
   xG1 <- xG[xG$sizeG == 1, ]
   if (dim(xG1)[1] > 0)
     {
-      Gn1 <- data.frame(level = "G", family = xG1$family, genus = xG1$genus, rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = xG1$species)
+      Gn1 <- data.frame(level = "G", family = xG1$family, genus = xG1$genus, rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = xG1$species, stringsAsFactors = FALSE)
       for (i in 1 : dim(Gn1)[1])
         {
           x0 <- match(Gn1$taxa[i], tree$tip.label)
@@ -129,7 +129,7 @@ function(tree, tips)
       n2 <- length(tG$tip.label) + 1 - which(!duplicated(rev(tG$tip.label)))
       nn <- sort(unique(c(n1, n2)))
       tG <- drop.tip(tG, setdiff(1:length(tG$tip.label), nn))
-      Gn2 <- data.frame(level = "G", family = xG2$family, genus = xG2$genus, rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = "")
+      Gn2 <- data.frame(level = "G", family = xG2$family, genus = xG2$genus, rn = "", rn.bl = 0, bn = "", bn.bl = 0, taxa = "", stringsAsFactors = FALSE)
       x<-1 : length(tG$tip.label)
       for (i in 1 : dim(Gn2)[1])
         {


### PR DESCRIPTION
Hello, 

I've found an error in the manual and I think some functions were broken. Factors cause this error from the example in man for build.nodes.1 : 
```
#### Example from the man ####
# make the tree and its tips information
phylogeny <- rcoal(10)  # generate a phylogeny with 10 tips
phylogeny$node.label <- paste("N",1:phylogeny$Nnode,sep="")  # label the nodes
phylogeny$tip.label <- paste(rep(rep(c("Genus1","Genus2"),2),4:1), phylogeny$tip.label, sep="_")   # rename the tips
tips <- data.frame(species = phylogeny$tip.label,genus=rep(rep(c("Genus1","Genus2"),2),4:1),family=rep(rep(c("Family1","Family2"),2),4:1)) # generate the tips information

# plot the tree
plot(phylogeny, show.node.label=TRUE, tip.color=rep(rep(c("black","red"),2),4:1),edge.width=1)

# generate the nodes information of the tree
nodes.inf<-build.nodes.1(phylogeny, tips)   # build the nodes information file for the phylogeny
# Error in if (n > min(tree$edge[, 1])) { : 
# length is null
# Also : Warning message:
# In `[<-.factor`(`*tmp*`, i, value = "N1") :
#  invalid factor level, NA generated
nodes.inf   # show the nodes.infomation file
```
I modified the data.frame formation in build.nodes.1 to force the absence of factors, by inserting `stringAsFactors = FALSE`. I suspect that some user have different `default.stringsAsFactors()` values in their R and forcing it in this function could secure the process.

Note that I didn't modify build.nodes.2 but it return the same error so I expect my solution to work in it as well.

I hope this modification didn't affect the result of the function, as there was no (small) data in the package to compare the output for a tree with 10 tips.

Thanks anyway for your package, it is helping my actual work.
Best regards,

Maxime Jaunatre